### PR TITLE
ci(renovate): add status check overrides

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,10 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   enabled: true,
-  extends: ["github>techtales-io/renovate-config:base.json5"],
+  extends: [
+    "github>techtales-io/renovate-config:base.json5",
+    "github>techtales-io/renovate-config//github-actions/disable-status-checks.json5",
+    "github>techtales-io/renovate-config//mise/disable-status-checks.json5",
+    "github>techtales-io/renovate-config//pre-commit/disable-status-checks.json5",
+  ],
 }


### PR DESCRIPTION
Add disable-status-checks presets for github-actions, mise, and pre-commit to match other repos.